### PR TITLE
Integrate frontend submission with backend DAG analysis

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,82 @@
-from fastapi import FastAPI, Form
+from collections import deque
+from typing import Any, Dict, List, Set
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+
+class PipelinePayload(BaseModel):
+    nodes: List[Dict[str, Any]]
+    edges: List[Dict[str, Any]]
+
 
 app = FastAPI()
 
-@app.get('/')
-def read_root():
-    return {'Ping': 'Pong'}
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
-@app.get('/pipelines/parse')
-def parse_pipeline(pipeline: str = Form(...)):
-    return {'status': 'parsed'}
+
+@app.get("/")
+def read_root():
+    return {"Ping": "Pong"}
+
+
+def _is_dag(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> bool:
+    node_ids: Set[Any] = {node.get("id") for node in nodes if node.get("id") is not None}
+
+    for edge in edges:
+        source = edge.get("source")
+        target = edge.get("target")
+        if source is not None:
+            node_ids.add(source)
+        if target is not None:
+            node_ids.add(target)
+
+    if not node_ids:
+        return True
+
+    adjacency: Dict[Any, List[Any]] = {node_id: [] for node_id in node_ids}
+    indegree: Dict[Any, int] = {node_id: 0 for node_id in node_ids}
+
+    for edge in edges:
+        source = edge.get("source")
+        target = edge.get("target")
+
+        if source is None or target is None:
+            continue
+
+        adjacency.setdefault(source, [])
+        adjacency.setdefault(target, [])
+        indegree.setdefault(source, 0)
+        indegree[target] = indegree.get(target, 0) + 1
+        adjacency[source].append(target)
+
+    zero_indegree = deque([node_id for node_id, degree in indegree.items() if degree == 0])
+    visited = 0
+
+    while zero_indegree:
+        node_id = zero_indegree.popleft()
+        visited += 1
+        for neighbor in adjacency.get(node_id, []):
+            indegree[neighbor] -= 1
+            if indegree[neighbor] == 0:
+                zero_indegree.append(neighbor)
+
+    return visited == len(indegree)
+
+
+@app.post("/pipelines/parse")
+def parse_pipeline(payload: PipelinePayload):
+    nodes = payload.nodes
+    edges = payload.edges
+    return {
+        "num_nodes": len(nodes),
+        "num_edges": len(edges),
+        "is_dag": _is_dag(nodes, edges),
+    }

--- a/frontend/src/submit.js
+++ b/frontend/src/submit.js
@@ -1,19 +1,60 @@
 // submit.js
 
-export const SubmitButton = () => {
+import { useCallback } from 'react';
+import { shallow } from 'zustand/shallow';
 
-    return (
-        <div className="submit">
-            <button type="submit" className="submit__button">
-                <span>Launch pipeline</span>
-                <svg className="submit__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                    <path
-                        d="M3.25 8h7.69L7.22 4.28a.75.75 0 011.06-1.06l4.75 4.75a.75.75 0 010 1.06l-4.75 4.75a.75.75 0 11-1.06-1.06L10.94 9.5H3.25a.75.75 0 010-1.5z"
-                        fill="currentColor"
-                    />
-                </svg>
-            </button>
-            <p className="submit__hint">Your configuration is saved automatically while you design.</p>
-        </div>
-    );
+import { useStore } from './store';
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+
+const selector = (state) => ({
+  nodes: state.nodes,
+  edges: state.edges,
+});
+
+export const SubmitButton = () => {
+  const { nodes, edges } = useStore(selector, shallow);
+
+  const handleSubmit = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/pipelines/parse`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ nodes, edges }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const result = await response.json();
+
+      window.alert(
+        `Pipeline summary:\n` +
+          `• Nodes: ${result.num_nodes}\n` +
+          `• Edges: ${result.num_edges}\n` +
+          `• Forms DAG: ${result.is_dag ? 'Yes' : 'No'}`
+      );
+    } catch (error) {
+      console.error('Failed to submit pipeline:', error);
+      window.alert('Unable to submit pipeline. Please try again.');
+    }
+  }, [nodes, edges]);
+
+  return (
+    <div className="submit">
+      <button type="button" className="submit__button" onClick={handleSubmit}>
+        <span>Launch pipeline</span>
+        <svg className="submit__icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M3.25 8h7.69L7.22 4.28a.75.75 0 011.06-1.06l4.75 4.75a.75.75 0 010 1.06l-4.75 4.75a.75.75 0 11-1.06-1.06L10.94 9.5H3.25a.75.75 0 010-1.5z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+      <p className="submit__hint">Your configuration is saved automatically while you design.</p>
+    </div>
+  );
 };


### PR DESCRIPTION
## Summary
- send the pipeline graph from the launch button to the backend parser and alert the returned stats
- extend the FastAPI endpoint to accept JSON payloads, enable CORS, and compute node/edge counts with DAG detection

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc304f6634832b8be82c77d222b4be