### PR TITLE
Fix sidebar search filtering

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -203,6 +203,16 @@
   scrollbar-color: rgba(148, 163, 184, 0.4) transparent;
 }
 
+.toolbar__empty-state {
+  grid-column: 1 / -1;
+  padding: 24px 12px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.52);
+  color: rgba(226, 232, 240, 0.72);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
 .toolbar__grid::-webkit-scrollbar {
   width: 6px;
 }

--- a/frontend/src/toolbar.js
+++ b/frontend/src/toolbar.js
@@ -1,9 +1,32 @@
 // toolbar.js
 
+import { useState } from 'react';
+
 import { DraggableNode } from './draggableNode';
 import { toolbarNodes } from './nodes';
 
 export const PipelineToolbar = () => {
+    const [searchTerm, setSearchTerm] = useState('');
+
+    const query = searchTerm.trim().toLowerCase();
+    const filteredToolbarNodes = query
+        ? toolbarNodes.filter(({ label, description, type }) => {
+              const normalizedLabel = label?.toLowerCase() ?? '';
+              const normalizedDescription = description?.toLowerCase() ?? '';
+              const normalizedType = type?.toLowerCase() ?? '';
+
+              return (
+                  normalizedLabel.includes(query) ||
+                  normalizedDescription.includes(query) ||
+                  normalizedType.includes(query)
+              );
+          })
+        : toolbarNodes;
+
+    const handleSearchChange = (event) => {
+        setSearchTerm(event.target.value);
+    };
+
     return (
         <div className="toolbar">
             <div className="toolbar__utilities">
@@ -14,20 +37,32 @@ export const PipelineToolbar = () => {
                             fill="currentColor"
                         />
                     </svg>
-                    <input type="search" placeholder="Search nodes" aria-label="Search nodes" />
+                    <input
+                        type="search"
+                        placeholder="Search nodes"
+                        aria-label="Search nodes"
+                        value={searchTerm}
+                        onChange={handleSearchChange}
+                    />
                 </div>
                 <span className="toolbar__hint">Drag any block to the canvas to begin building.</span>
             </div>
             <div className="toolbar__grid">
-                {toolbarNodes.map(({ type, label, description, accentColor }) => (
-                    <DraggableNode
-                        key={type}
-                        type={type}
-                        label={label}
-                        description={description}
-                        accentColor={accentColor}
-                    />
-                ))}
+                {filteredToolbarNodes.length === 0 ? (
+                    <div className="toolbar__empty-state" role="status">
+                        No nodes match your search.
+                    </div>
+                ) : (
+                    filteredToolbarNodes.map(({ type, label, description, accentColor }) => (
+                        <DraggableNode
+                            key={type}
+                            type={type}
+                            label={label}
+                            description={description}
+                            accentColor={accentColor}
+                        />
+                    ))
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- wire up the sidebar toolbar search input to filter nodes by type, label, or description
- add an empty-state message when no nodes match the current search
- style the empty-state message to blend with the existing toolbar visuals

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68cd9bfea994832b961e0cc538818e3b